### PR TITLE
[NM-39] Create minimal docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,48 +1,22 @@
-FROM ghcr.io/hivtools/naomi-base:latest
-
-RUN apt-get update && apt-get -y install --no-install-recommends \
-        libhiredis-dev \
-        libjq-dev \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*
-
-RUN install_packages --repo=https://mrc-ide.r-universe.dev \
-        callr \
-        docopt \
-        eppasm \
-        geojsonio \
-        glue \
-        jsonlite \
-        jsonvalidate \
-        lgr \
-        naomi.options \
-        first90 \
-        plumber \
-        porcelain \
-        ps \
-        remotes \
-        rlang \
-        rrq
-
-
-COPY docker/bin /usr/local/bin/
-
-# If tracking development versions of packages, install via
-# github. However, limt this (and prefer updating the drat) as this
-# can hit rate limits as we cannot use a PAT when building the
-# container.
-# RUN install_remote \
-#    mrc-ide/naomi.options
+FROM ghcr.io/hivtools/naomi-base:minimal
 
 COPY . /src
-RUN R CMD INSTALL /src/naomi \
-    && cd /src && ./scripts/build_test_data \
-    && R CMD INSTALL /src
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+COPY docker/bin /usr/local/bin/
+
+RUN cd /src \
+    && ./scripts/build_test_data \
+    && find /src/inst/output -type f ! -name "malawi_model_output.qs" -delete \
+    && R CMD INSTALL /src \
+    && rm -r /src
 
 EXPOSE 8888
 ENV HINTR_QUEUE_ID=hintr
+
 ## Model run will try to parallelise over as many threads as are available
 ## potentially slowing the application, manually limit threads to 1
 ENV OMP_NUM_THREADS=1
+
+WORKDIR /
 
 ENTRYPOINT ["/usr/local/bin/hintr_api"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,37 @@
-FROM ghcr.io/hivtools/naomi-base:minimal
+FROM ghcr.io/hivtools/naomi-base:latest AS build
 
 COPY . /src
-COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 COPY docker/bin /usr/local/bin/
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
-RUN cd /src \
-    && ./scripts/build_test_data \
+## Remove the large test data not needed for runtime
+RUN install_packages remotes \
+    && install_remote mrc-ide/naomi \
+    && rm -r /usr/local/lib/R/site-library/naomi/extdata
+
+WORKDIR /src
+RUN ./scripts/build_test_data \
     && find /src/inst/output -type f ! -name "malawi_model_output.qs" -delete \
     && R CMD INSTALL /src \
     && rm -r /src
+
+FROM rocker/r-ver:4 AS run
+
+## Install just the runtime-dependencies
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        libudunits2-0 \
+        libhiredis1.1.0 \
+        libjq1 \
+        libsodium23 \
+        libssl3 \
+        gdal-bin \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /tmp/*
+
+COPY --from=build /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /usr/bin/pandoc /usr/bin/pandoc
 
 EXPOSE 8888
 ENV HINTR_QUEUE_ID=hintr

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,1 +1,1 @@
-options(knitr.chunk.dev = 'svglite')
+options(repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/noble/latest'), download.file.method = 'libcurl')

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,0 +1,1 @@
+options(knitr.chunk.dev = 'svglite')


### PR DESCRIPTION
We want to cut down the size of docker images as in move to cloud the start-up time of a model fit is dependent on the time it takes to spin up the container. So spinning up a container will take ~30s to pull the docker image and then it will start and run the model fit. I've played around with a few things here trying to cut this down, with some mixed success.

I tried a build with https://github.com/r-hub/r-minimal but I was seeing significant hit to performance. ~30% slower. I didn't look into the super deeply but I expect it is the musl allocator being slower than glibc.

So that means we need to go with debian based image. First simple thing I tried here was using a multistage build and this is a big improvement, with the rocker/r-ver as the base image.

Current main has sizes like this
- Compressed local - 2.3G
- Compressed remote - 2.31G
- Uncompressed - 5.9G

After using multi stage build
- compressed local - 619M

I then played around with trying to use a slimmer base image for the run-time. I gave it a go with distroless but with not much success getting a slimmer image. I'm sure it will be possible, just quite fiddly and wasn't seeing immediate gains so didn't think it was worthwhile pursing.

I think if we want to make a smaller image from this, two things we could look at
1. Use the 2nd part of the multistage build to start from a slimmer image (debian-slim?, distroless) and only copy over the things we need a run time. I think it is quite challenging to work out only exactly what we need.
2. Reduce the number of packages and dependencies we need

I think 2 might be easier, particularly because the image size is only really really important for model running, if we look at the packages that are installed we can think of them in a few groups
Looking at sizes of image, most of it is R package dependencies, unsurprisingly roughly into several large groups
1. Boost headers (what is requiring this - this is used by eppasm, first90 and qs)
2. Markdown stuff (RMarkdown, pandoc, knitr, bslib etc)
3. duckdb
4. Rcpp (Rcpp, RcppEigen, rcppParallel)
5. Shape file stuff (gdal, sp, geojsonio, geojsonsf, dpdep)
6. Other file writing things (openxlsx, data.table)
7. API stuff (hintr, V8, lgr)

For actual model fitting we don't need all of this, we could split naomi model into a separate package and build that into a docker image. We could definitely remove markdown stuff, file writing pacakges, api packages. Potentially also duckdb (I think we only need this after calibrating). Potentially also Rcpp things, do we need these after we have already compiled? Perhaps TMB needs them?