### PR TITLE
[nm-42] Make it impossible to accidentally destroy redis data

### DIFF
--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -26,7 +26,9 @@ MockQueue <- R6::R6Class(
 )
 
 test_queue <- function(workers = 0) {
-  queue <- Queue$new(workers = workers, timeout = 300)
+  queue <- Queue$new(workers = workers,
+                     timeout = 300,
+                     delete_data_on_exit = TRUE)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()
@@ -48,9 +50,10 @@ create_blocking_worker <- function(controller, worker_name = NULL) {
                        worker_id = worker_name)
 }
 
-test_queue_result <- function(model = mock_model, calibrate = mock_calibrate,
+test_queue_result <- function(model = mock_model,
+                              calibrate = mock_calibrate,
                               clone_output = TRUE) {
-  queue <- Queue$new(workers = 1, timeout = 300)
+  queue <- Queue$new(workers = 1, timeout = 300, delete_data_on_exit = TRUE)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -2,7 +2,7 @@ test_that("queue works as intended", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- Queue$new(timeout = 300)
+  queue <- Queue$new(timeout = 300, delete_data_on_exit = TRUE)
   ctrl <- queue$controller
   expect_equal(rrq::rrq_worker_len(controller = ctrl), 2)
 
@@ -105,7 +105,7 @@ test_that("test queue starts workers with timeout", {
 })
 
 test_that("queue starts up normally without a timeout", {
-  queue <- Queue$new(workers = 1)
+  queue <- Queue$new(workers = 1, delete_data_on_exit = TRUE)
   on.exit(queue$cleanup())
   timeout <- rrq::rrq_message_send_and_wait(
     "TIMEOUT_GET",


### PR DESCRIPTION
This PR will 
* Change the queue cleanup code so that data will not be deleted from redis unless you explicitly opt in

Should hopefully avoid recreating the accidental delete of all of our records which happened the other day :see_no_evil: 