### PR TITLE
Force download endpoint to error on coarse output generation for testing

### DIFF
--- a/R/downloads.R
+++ b/R/downloads.R
@@ -31,6 +31,9 @@ download <- function(model_output, type, path_results, input, language = NULL) {
   } else if (type == "agyw") {
     out <- naomi::hintr_prepare_agyw_download(model_output, input$pjnz,
                                               download_path)
+  } else if (type == "coarse_output") {
+    hintr_error("Download err beep boop!",
+                "FAILED_DOWNLOAD")
   } else {
     func <- switch(type,
                    coarse_output = naomi::hintr_prepare_coarse_age_group_download,


### PR DESCRIPTION
Should not be merged, a PR just for us to check error behaviour on download. This will make the coarse output always error.