### PR TITLE
[NM-61] Update population endpoint to return data and metadata for population pyramid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.2.7
+Version: 1.2.8
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.2.8
+
+* Return data and metadata from population validation endpoint
+
 # hintr 1.2.7
 
 * Return a more human readable error message when reading a csv fails in spectacular fashion.

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -9,6 +9,9 @@ input_response <- function(value, type, file) {
   if (!is.null(value$warnings)) {
     ret$warnings <- warnings_scalar(value$warnings)
   }
+  if (!is.null(value$metadata)) {
+    ret$metadata <- value$metadata
+  }
   validate_json_schema(to_json(ret), get_input_response_schema(type), "data")
   ret
 }

--- a/R/filters.R
+++ b/R/filters.R
@@ -269,9 +269,9 @@ get_selected_mappings <- function(mappings, type, ids = NULL, key = "options") {
   selected
 }
 
-get_quarter_filters <- function(data) {
+get_quarter_filters <- function(data, decreasing = TRUE) {
   calendar_quarters <- unique(data$calendar_quarter)
-  calendar_quarters <- sort(calendar_quarters, decreasing = TRUE)
+  calendar_quarters <- sort(calendar_quarters, decreasing = decreasing)
   lapply(calendar_quarters, function(quarter) {
     list(id = scalar(as.character(quarter)),
          label = scalar(get_quarter_label(quarter)))

--- a/R/population_metadata.R
+++ b/R/population_metadata.R
@@ -15,7 +15,7 @@ population_pyramid_metadata <- function(data) {
     list(
       id = scalar("calendar_quarter"),
       column_id = scalar("calendar_quarter"),
-      options = get_quarter_filters(data)
+      options = get_quarter_filters(data, decreasing = FALSE)
     ),
     age_filter <- list(
       id = scalar("age"),

--- a/R/population_metadata.R
+++ b/R/population_metadata.R
@@ -34,9 +34,9 @@ population_pyramid_metadata <- function(data) {
                                                list(iso3 = "default"))
   control_options <- lapply(seq(nrow(indicator_metadata)), function(row_no) {
     list(
-      id = indicator_metadata[row_no, "indicator"],
-      label = indicator_metadata[row_no, "name"],
-      effect = list()
+      id = scalar(indicator_metadata[row_no, "indicator"]),
+      label = scalar(indicator_metadata[row_no, "name"]),
+      effect = setNames(list(), list())
     )
   })
   list(
@@ -65,9 +65,8 @@ population_pyramid_metadata <- function(data) {
         ),
         plotSettings = list(
           list(
-            id = "plot",
-            label = t_("INPUT_TIME_SERIES_COLUMN_PLOT_TYPE"),
-            value = "population",
+            id = scalar("plot"),
+            label = scalar(t_("INPUT_TIME_SERIES_COLUMN_PLOT_TYPE")),
             options = control_options
           )
         )

--- a/R/population_metadata.R
+++ b/R/population_metadata.R
@@ -1,0 +1,77 @@
+population_pyramid_metadata <- function(data) {
+  filter_types <- list(
+    list(
+      id = scalar("area"),
+      column_id = scalar("area_id"),
+      options = json_verbatim("null"),
+      use_shape_regions = scalar(TRUE)
+    ),
+    list(
+      id = scalar("area_level"),
+      column_id = scalar("area_level"),
+      options = json_verbatim("null"),
+      use_shape_area_level = scalar(TRUE)
+    ),
+    list(
+      id = scalar("calendar_quarter"),
+      column_id = scalar("calendar_quarter"),
+      options = get_quarter_filters(data)
+    ),
+    age_filter <- list(
+      id = scalar("age"),
+      column_id = scalar("age_group"),
+      options = get_age_filters(data)
+    ),
+    sex_filter <- list(
+      id = scalar("sex"),
+      column_id = scalar("sex"),
+      options = get_sex_filters(data)
+    )
+  )
+  ## Use default here as country is only used for specific colours but
+  ## population pyramid has the same colours for all countries
+  indicator_metadata <- get_indicator_metadata("population", "pyramid",
+                                               list(iso3 = "default"))
+  control_options <- lapply(seq(nrow(indicator_metadata)), function(row_no) {
+    list(
+      id = indicator_metadata[row_no, "indicator"],
+      label = indicator_metadata[row_no, "name"],
+      effect = list()
+    )
+  })
+  list(
+    filterTypes = filter_types,
+    indicators = indicator_metadata,
+    plotSettingsControl = list(
+      population = list(
+        defaultEffect = list(
+          setFilters = list(
+            list(
+              filterId = scalar("area_level"),
+              label = scalar(t_("OUTPUT_FILTER_AREA_LEVEL")),
+              stateFilterId = scalar("area_level")
+            ),
+            list(
+              filterId = scalar("area"),
+              label = scalar(t_("OUTPUT_FILTER_AREA")),
+              stateFilterId = scalar("area")
+            ),
+            list(
+              filterId = scalar("calendar_quarter"),
+              label = scalar(t_("OUTPUT_FILTER_PERIOD")),
+              stateFilterId = scalar("calendar_quarter")
+            )
+          )
+        ),
+        plotSettings = list(
+          list(
+            id = "plot",
+            label = t_("INPUT_TIME_SERIES_COLUMN_PLOT_TYPE"),
+            value = "population",
+            options = control_options
+          )
+        )
+      )
+    )
+  )
+}

--- a/R/population_metadata.R
+++ b/R/population_metadata.R
@@ -61,7 +61,8 @@ population_pyramid_metadata <- function(data) {
               label = scalar(t_("OUTPUT_FILTER_PERIOD")),
               stateFilterId = scalar("calendar_quarter")
             )
-          )
+          ),
+          setMultiple = c("area")
         ),
         plotSettings = list(
           list(

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -94,7 +94,8 @@ do_validate_population <- function(population) {
   assert_single_country(population, "population")
   assert_column_names(
     colnames(population),
-    c("area_id", "calendar_quarter", "sex", "age_group", "source", "population"))
+    c("area_id", "area_name", "calendar_quarter", "sex", "age_group",
+      "source", "population"))
   assert_calendar_quarter_column(population)
   assert_expected_values(population, "sex", c("male", "female"), all_values = TRUE)
   assert_expected_values(population, "age_group", naomi::get_five_year_age_groups(), all_values = TRUE)
@@ -103,8 +104,8 @@ do_validate_population <- function(population) {
   assert_no_na(population, "population")
   assert_column_positive_numeric(population, "population")
 
-  return_data <- population[, c("area_id", "calendar_quarter", "sex",
-                                "age_group", "population")]
+  return_data <- population[, c("area_id", "area_name", "calendar_quarter",
+                                "sex", "age_group", "population")]
   # Population data sometimes interpolated so it has many decimal points
   # reduce payload size here by rounding early, we never want to display it
   # more precisely than to nearest 1.

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -102,8 +102,16 @@ do_validate_population <- function(population) {
   assert_single_source(population)
   assert_no_na(population, "population")
   assert_column_positive_numeric(population, "population")
-  list(data = json_verbatim("null"),
-       filters = json_verbatim("null"))
+
+  return_data <- population[, c("area_id", "calendar_quarter", "sex",
+                                "age_group", "population")]
+  # Population data sometimes interpolated so it has many decimal points
+  # reduce payload size here by rounding early, we never want to display it
+  # more precisely than to nearest 1.
+  return_data$population <- round(return_data$population)
+  metadata <- population_pyramid_metadata(return_data)
+  list(data = return_data,
+       metadata = metadata)
 }
 
 #' Validate programme ART data file.

--- a/inst/schema/Filter.schema.json
+++ b/inst/schema/Filter.schema.json
@@ -17,6 +17,9 @@
     },
     "use_shape_regions": {
       "type": [ "boolean", "null" ]
+    },
+    "use_shape_area_level": {
+      "type": [ "boolean", "null" ]
     }
   },
   "additionalProperties": false,

--- a/inst/schema/FilterTypes.schema.json
+++ b/inst/schema/FilterTypes.schema.json
@@ -14,6 +14,9 @@
         },
         "use_shape_regions": {
             "type": "boolean"
+        },
+        "use_shape_area_level": {
+            "type": "boolean"
         }
     },
     "additionalProperties": false,

--- a/inst/schema/PopulationDataRow.schema.json
+++ b/inst/schema/PopulationDataRow.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "area_id": {
+      "type": "string"
+    },
+    "calendar_quarter": {
+      "type": "string"
+    },
+    "sex": {
+      "type": "string"
+    },
+    "age_group": {
+      "type": "string"
+    },
+    "population": {
+      "type": "number"
+    }
+  },
+  "additionalProperties": true,
+  "required": [ "area_id", "calendar_quarter", "sex", "age_group",
+                "population" ]
+}

--- a/inst/schema/PopulationDataRow.schema.json
+++ b/inst/schema/PopulationDataRow.schema.json
@@ -5,6 +5,9 @@
     "area_id": {
       "type": "string"
     },
+    "area_name": {
+      "type": "string"
+    },
     "calendar_quarter": {
       "type": "string"
     },
@@ -19,6 +22,6 @@
     }
   },
   "additionalProperties": true,
-  "required": [ "area_id", "calendar_quarter", "sex", "age_group",
+  "required": [ "area_id", "area_name", "calendar_quarter", "sex", "age_group",
                 "population" ]
 }

--- a/inst/schema/PopulationResponseData.schema.json
+++ b/inst/schema/PopulationResponseData.schema.json
@@ -1,4 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "null"
+  "type": "array",
+  "items": { "$ref": "PopulationDataRow.schema.json" }
 }

--- a/inst/schema/PopulationResponseMetadata.schema.json
+++ b/inst/schema/PopulationResponseMetadata.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "filterTypes": {
+      "type": "array",
+      "items": { "$ref": "FilterTypes.schema.json" }
+    },
+    "indicators": {
+      "type": "array",
+      "items": { "$ref": "IndicatorMetadata.schema.json" }
+    },
+    "plotSettingsControl": {
+      "type": "object",
+      "properties": {
+        "population": { "$ref": "PlotSettingsControl.schema.json" }
+      },
+      "additionalProperties": false,
+      "required": ["population"]
+    }
+  },
+  "required": [ "filterTypes", "indicators", "plotSettingsControl" ]
+}

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -58,7 +58,7 @@
           "enum": [ "population" ]
         },
         "data": { "$ref": "PopulationResponseData.schema.json" },
-        "filters": { "type": "null" }
+        "metadata": { "$ref": "PopulationResponseMetadata.schema.json" }
       },
       "additionalProperties": false,
       "required": ["filename", "hash", "type", "data"]

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -58,10 +58,11 @@
           "enum": [ "population" ]
         },
         "data": { "$ref": "PopulationResponseData.schema.json" },
-        "metadata": { "$ref": "PopulationResponseMetadata.schema.json" }
+        "metadata": { "$ref": "PopulationResponseMetadata.schema.json" },
+        "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["filename", "hash", "type", "data"]
+      "required": ["filename", "hash", "type", "data", "metadata"]
     },
 
     "programme_response": {

--- a/tests/testthat/helper-expect-metadata.R
+++ b/tests/testthat/helper-expect-metadata.R
@@ -140,7 +140,7 @@ expect_population_metadata <- function(metadata) {
   }
   expect_true(length(metadata$indicators) > 0)
   indicators <- vcapply(metadata$indicators, "[[", "indicator")
-  expect_setequal(indicators, c("population", "population_ratio"))
+  expect_setequal(indicators, c("population", "population_proportion"))
 
   filters <- lapply(metadata$filterTypes, "[[", "column_id")
   ## Ignore attr below as before serialization this will be wrapped in a scalar

--- a/tests/testthat/helper-expect-metadata.R
+++ b/tests/testthat/helper-expect-metadata.R
@@ -8,6 +8,9 @@
 ## of simplifyVector in call to simplifyVector
 ## Use this so that we can use same test for data frame and list type
 df_to_list <- function(x) {
+  if (nrow(x) == 0) {
+    return(list())
+  }
   lapply(seq(nrow(x)), function(row_num) { as.list(x[row_num, ])})
 }
 
@@ -118,14 +121,35 @@ expect_input_comparison_metadata <- function(metadata) {
            sprintf("filter '%s' has no options", filter$id))
   }
 
-  filters <- lapply(metadata$filterTypes, "[[",
-                    "column_id")
+  filters <- lapply(metadata$filterTypes, "[[", "column_id")
   ## Ignore attr below as before serialization this will be wrapped in a scalar
   ## class but afterwards it won't
   expect_equal(filters[[1]], "indicator", ignore_attr = TRUE)
   expect_equal(filters[[2]], "area_name", ignore_attr = TRUE)
   expect_equal(filters[[3]], "year", ignore_attr = TRUE)
   expect_equal(filters[[4]], "group", ignore_attr = TRUE)
+}
+
+expect_population_metadata <- function(metadata) {
+  expect_valid_metadata(metadata)
+  expect_equal(names(metadata),
+               c("filterTypes", "indicators", "plotSettingsControl"))
+
+  if (is.data.frame(metadata$indicators)) {
+    metadata$indicators <- df_to_list(metadata$indicators)
+  }
+  expect_true(length(metadata$indicators) > 0)
+  indicators <- vcapply(metadata$indicators, "[[", "indicator")
+  expect_setequal(indicators, c("population", "population_ratio"))
+
+  filters <- lapply(metadata$filterTypes, "[[", "column_id")
+  ## Ignore attr below as before serialization this will be wrapped in a scalar
+  ## class but afterwards it won't
+  expect_equal(filters[[1]], "area_id", ignore_attr = TRUE)
+  expect_equal(filters[[2]], "area_level", ignore_attr = TRUE)
+  expect_equal(filters[[3]], "calendar_quarter", ignore_attr = TRUE)
+  expect_equal(filters[[4]], "age_group", ignore_attr = TRUE)
+  expect_equal(filters[[5]], "sex", ignore_attr = TRUE)
 }
 
 mock_filter_types <- function(ids) {

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -74,7 +74,7 @@ test_that("validate population", {
   expect_null(res$data$filters)
 
   expect_setequal(names(res$data$data[[1]]),
-                  c("area_id", "calendar_quarter",
+                  c("area_id", "area_name", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(length(res$data$data) > 100)
   expect_population_metadata(res$data$metadata)

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -63,16 +63,21 @@ test_that("validate population", {
     body = payload,
     httr::content_type_json())
   expect_equal(httr::status_code(r), 200)
-  expect_equal(response_from_json(r), list(
-    status = "success",
-    errors = NULL,
-    data = list(hash = "12345",
-                type = "population",
-                data = NULL,
-                filename = "original.csv",
-                fromADR = FALSE,
-                resource_url = NULL,
-                filters = NULL)))
+  res <- response_from_json(r)
+  expect_equal(res$status, "success")
+  expect_null(res$errors)
+  expect_equal(res$data$hash, "12345")
+  expect_equal(res$data$type, "population")
+  expect_equal(res$data$filename, "original.csv")
+  expect_false(res$data$fromADR)
+  expect_null(res$data$resource_url)
+  expect_null(res$data$filters)
+
+  expect_setequal(names(res$data$data[[1]]),
+                  c("area_id", "calendar_quarter",
+                    "sex", "age_group", "population"))
+  expect_true(length(res$data$data) > 100)
+  expect_population_metadata(res$data$metadata)
 })
 
 test_that("validate programme", {

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -145,7 +145,7 @@ test_that("endpoint_validate_baseline supports population file", {
   expect_equal(response$fromADR, scalar(FALSE))
 
   expect_setequal(colnames(response$data),
-                  c("area_id", "calendar_quarter",
+                  c("area_id", "area_name", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(nrow(response$data) > 100)
   ## Data is rounded i.e. no decimal point

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -142,6 +142,13 @@ test_that("endpoint_validate_baseline supports population file", {
 
   expect_equal(response$filename, scalar("original"))
   expect_equal(response$hash, scalar("12345"))
-  expect_equal(response$data, json_null())
   expect_equal(response$fromADR, scalar(FALSE))
+
+  expect_setequal(colnames(response$data),
+                  c("area_id", "calendar_quarter",
+                    "sex", "age_group", "population"))
+  expect_true(nrow(response$data) > 100)
+  ## Data is rounded i.e. no decimal point
+  expect_false(grepl("\\.", as.character(response$data$population[[1]])))
+  expect_population_metadata(response$metadata)
 })

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -57,7 +57,7 @@ test_that("do_validate_population validates population file", {
   pop <- do_validate_population(population)
 
   expect_setequal(colnames(pop$data),
-                  c("area_id", "calendar_quarter",
+                  c("area_id", "area_name", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(nrow(pop$data) > 100)
   ## Data is rounded i.e. no decimal point

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -55,8 +55,14 @@ test_that("do_validate_shape returns if display property is missing", {
 test_that("do_validate_population validates population file", {
   population <- file_object(file.path("testdata", "population.csv"))
   pop <- do_validate_population(population)
-  ## No actual data to return but has been validated
-  expect_equal(pop$data, json_verbatim("null"))
+
+  expect_setequal(colnames(pop$data),
+                  c("area_id", "calendar_quarter",
+                    "sex", "age_group", "population"))
+  expect_true(nrow(pop$data) > 100)
+  ## Data is rounded i.e. no decimal point
+  expect_false(grepl("\\.", as.character(pop$data$population[[1]])))
+  expect_population_metadata(pop$metadata)
 })
 
 test_that("empty rows are ignored in validation", {
@@ -85,8 +91,9 @@ test_that("empty rows are ignored in validation", {
 ",,,,,,"), path)
   population <- file_object(path)
   pop <- do_validate_population(population)
-  ## No actual data to return but has been validated
-  expect_equal(pop$data, json_verbatim("null"))
+
+  # Check these empty rows have been ignored
+  expect_equal(nrow(pop$data), 17)
 })
 
 test_that("do_validate_programme validates programme file", {


### PR DESCRIPTION
This PR will
* Return data and metadata from the `validate/baseline-individual` for the population file which we can use for building the population pyramid plots