### PR TITLE
Remove area_name as a returned field from population data

### DIFF
--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -94,8 +94,8 @@ do_validate_population <- function(population) {
   assert_single_country(population, "population")
   assert_column_names(
     colnames(population),
-    c("area_id", "area_name", "calendar_quarter", "sex", "age_group",
-      "source", "population"))
+    c("area_id", "calendar_quarter", "sex", "age_group", "source",
+      "population"))
   assert_calendar_quarter_column(population)
   assert_expected_values(population, "sex", c("male", "female"), all_values = TRUE)
   assert_expected_values(population, "age_group", naomi::get_five_year_age_groups(), all_values = TRUE)
@@ -104,7 +104,7 @@ do_validate_population <- function(population) {
   assert_no_na(population, "population")
   assert_column_positive_numeric(population, "population")
 
-  return_data <- population[, c("area_id", "area_name", "calendar_quarter",
+  return_data <- population[, c("area_id", "calendar_quarter",
                                 "sex", "age_group", "population")]
   # Population data sometimes interpolated so it has many decimal points
   # reduce payload size here by rounding early, we never want to display it

--- a/inst/schema/PopulationDataRow.schema.json
+++ b/inst/schema/PopulationDataRow.schema.json
@@ -5,9 +5,6 @@
     "area_id": {
       "type": "string"
     },
-    "area_name": {
-      "type": "string"
-    },
     "calendar_quarter": {
       "type": "string"
     },
@@ -22,6 +19,5 @@
     }
   },
   "additionalProperties": true,
-  "required": [ "area_id", "area_name", "calendar_quarter", "sex", "age_group",
-                "population" ]
+  "required": [ "area_id", "calendar_quarter", "sex", "age_group", "population" ]
 }

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -74,7 +74,7 @@ test_that("validate population", {
   expect_null(res$data$filters)
 
   expect_setequal(names(res$data$data[[1]]),
-                  c("area_id", "area_name", "calendar_quarter",
+                  c("area_id", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(length(res$data$data) > 100)
 })

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -145,7 +145,7 @@ test_that("endpoint_validate_baseline supports population file", {
   expect_equal(response$fromADR, scalar(FALSE))
 
   expect_setequal(colnames(response$data),
-                  c("area_id", "area_name", "calendar_quarter",
+                  c("area_id", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(nrow(response$data) > 100)
   ## Data is rounded i.e. no decimal point

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -57,7 +57,7 @@ test_that("do_validate_population validates population file", {
   pop <- do_validate_population(population)
 
   expect_setequal(colnames(pop$data),
-                  c("area_id", "area_name", "calendar_quarter",
+                  c("area_id", "calendar_quarter",
                     "sex", "age_group", "population"))
   expect_true(nrow(pop$data) > 100)
   ## Data is rounded i.e. no decimal point


### PR DESCRIPTION
We can get this from the new getters from the area file instead