### PR TITLE
[NM-115] Add ability to configure workers and queues via json

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.2.12
+Version: 1.2.13
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Additional_repositories: https://mrc-ide.r-universe.dev 
 Imports:
-    data.table,
     digest,
     docopt,
     dplyr,
@@ -29,6 +28,7 @@ Imports:
     porcelain (>= 0.1.8),
     qs,
     R6,
+    readr,
     readxl,
     rlang,
     rrq (>= 0.7.15),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.2.13
+
+* Update worker configuration setup to accept a json configuration file instead of being hardcoded in the package.
+
 # hintr 1.2.12
 
 * Update ART comparison table data and metadata to return adjusted and unadjusted spectrum values.

--- a/R/common.R
+++ b/R/common.R
@@ -1,6 +1,4 @@
 ## This file contains "hintr constants"
-QUEUE_CALIBRATE <- "calibrate"
-QUEUE_RUN <- "run"
 PROJECT_STATE_PATH <- file.path("info", "project_state.json")
 NOTES_PATH <- "notes.txt"
 INDICATORS_PATH <- "indicators.csv"

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -276,7 +276,7 @@ get_anc_map_filter_types <- function(input) {
 }
 
 get_programme_map_filter_types <- function(input) {
-  data <- read_csv(input$data$programme$path, header = TRUE)
+  data <- read_csv(input$data$programme$path, col_names = TRUE)
   quarter_filter <- list(
     id = scalar("map_programme_quarter"),
     column_id = scalar("calendar_quarter"),
@@ -301,7 +301,7 @@ get_programme_map_filter_types <- function(input) {
 }
 
 get_survey_map_filter_types <- function(input) {
-  data <- read_csv(input$data$survey$path, header = TRUE)
+  data <- read_csv(input$data$survey$path, col_names = TRUE)
   age_filter <- list(
     id = scalar("map_survey_age"),
     column_id = scalar("age_group"),

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -578,7 +578,8 @@ submit_model <- function(queue) {
       hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
     withCallingHandlers(
-      list(id = scalar(queue$submit_model_run(input$data, input$options))),
+      list(id = scalar(queue$submit_model_run(input$data, input$options,
+                                              input$iso3))),
       error = function(e) {
         hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }
@@ -624,7 +625,8 @@ submit_calibrate <- function(queue) {
     }
     withCallingHandlers(
       list(id = scalar(queue$submit_calibrate(queue$result(id),
-                                              calibration_options$options))),
+                                              calibration_options$options,
+                                              calibration_options$iso3))),
       error = function(e) {
         hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }
@@ -788,7 +790,8 @@ download_submit <- function(queue) {
     }
     withCallingHandlers(
       list(id = scalar(
-        queue$submit_download(queue$result(id), type, prepared_input))),
+        queue$submit_download(queue$result(id), type, prepared_input,
+                              parsed_input$iso3))),
       error = function(e) {
         hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }

--- a/R/main.R
+++ b/R/main.R
@@ -37,24 +37,18 @@ main_api <- function(args = commandArgs(TRUE)) {
 
 main_worker_args <- function(args = commandArgs(TRUE)) {
   usage <- "Usage:
-hintr_worker [options] [<queue_id>]
-
-Options:
---calibrate-only  Start a worker which will only run calibration tasks"
+hintr_worker [<worker_config>] [<queue_id>]"
   dat <- docopt_parse(usage, args)
   list(queue_id = dat$queue_id,
-       calibrate_only = dat$calibrate_only)
+       worker_config = dat$worker_config)
 }
 
 main_worker <- function(args = commandArgs(TRUE)) {
   # nocov start
   args <- main_worker_args(args)
-  worker_config <- "localhost"
-  if (args$calibrate_only) {
-    worker_config <- "calibrate_only"
-  }
+  validate_worker_name(args$worker_config)
   worker <- rrq_worker_new(hintr_queue_id(args$queue_id, TRUE),
-                           name_config = worker_config)
+                           name_config = args$worker_config)
   worker$loop()
   invisible(TRUE)
   # nocov end
@@ -68,23 +62,17 @@ rrq_worker_new <- function(...) {
 
 main_worker_single_job_args <- function(args = commandArgs(TRUE)) {
   usage <- "Usage:
-hintr_worker_single_job [options] [<queue_id>]
-
-Options:
---fit-only  Start a worker which will only run model fit"
+hintr_worker_single_job [<worker_config>] [<queue_id>]"
   dat <- docopt_parse(usage, args)
   list(queue_id = dat$queue_id,
-       fit_only = dat$fit_only)
+       worker_config = dat$worker_config)
 }
 
 main_worker_single_job <- function(args = commandArgs(TRUE)) {
   # nocov start
   args <- main_worker_single_job_args(args)
-  worker_config <- "localhost"
-  if (args$fit_only) {
-    worker_config <- "fit_only"
-  }
-  worker_single_job(hintr_queue_id(args$queue_id, TRUE), worker_config)
+  validate_worker_name(args$worker_config)
+  worker_single_job(hintr_queue_id(args$queue_id, TRUE), args$worker_config)
   # nocov end
 }
 

--- a/R/payload_helpers.R
+++ b/R/payload_helpers.R
@@ -57,10 +57,7 @@ setup_payload_download_request <- function(version = NULL,
                                            include_state = TRUE,
                                            include_pjnz = FALSE,
                                            include_vmmc = FALSE) {
-  if (!any(include_notes, include_state, include_pjnz)) {
-    stop("Must include one or more of notes, state or pjnz in payload")
-  }
-  payload <- list()
+  payload <- list('"iso3": "MWI"')
   path <- tempfile()
   if (include_notes) {
     notes <- paste0(readLines(

--- a/R/population_metadata.R
+++ b/R/population_metadata.R
@@ -2,7 +2,7 @@ population_metadata <- function(input) {
   input <- jsonlite::fromJSON(input)
   withCallingHandlers({
     assert_file_exists(input$population$path)
-    population <- read_csv(input$population$path, header = TRUE)
+    population <- read_csv(input$population$path, col_names = TRUE)
   }, error = function(e) {
     hintr_error(t_("FAILED_READ_CSV"), "INVALID_FILE")
   })

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -19,21 +19,18 @@ read_geojson_data <- function(shape) {
 }
 
 read_csv_regions <- function(csv_file) {
-  data <- read_csv(csv_file$path, header = TRUE)
+  data <- read_csv(csv_file$path, col_names = TRUE)
   unique(data$area_id)
 }
 
 read_csv <- function(file, ...) {
-  ## Make fread error early if any warning thrown e.g. because of
+  ## Make read_delim error early if any warning thrown e.g. because of
   ## partially read data
-  data <- withr::with_options(list(warn = 3),
-    data.table::fread(file, ...,
-                      blank.lines.skip = TRUE,
-                      data.table = FALSE,
-                      nThread = 1,
-                      na.strings = c("NA", ""))
-  )
-  data[rowSums(is.na(data)) != ncol(data), ]
+  readr::read_delim(file, ...,
+                    show_col_types = FALSE,
+                    name_repair = "minimal")
+  readr::stop_for_problems(data)
+  as.data.frame(data[rowSums(is.na(data)) != ncol(data), ])
 }
 
 read_pjnz_iso3 <- function(pjnz) {

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -86,7 +86,7 @@ do_validate_shape <- function(shape) {
 do_validate_population <- function(population) {
   assert_file_extension(population, "csv")
   withCallingHandlers(
-    population <- read_csv(population$path, header = TRUE),
+    population <- read_csv(population$path, col_names = TRUE),
     error = function(e) {
       hintr_error(t_("FAILED_READ_CSV"), "INVALID_FILE")
     }
@@ -131,7 +131,7 @@ do_validate_population <- function(population) {
 do_validate_programme <- function(programme, shape, strict = TRUE) {
   assert_file_extension(programme, "csv")
   withCallingHandlers(
-    data <- read_csv(programme$path, header = TRUE),
+    data <- read_csv(programme$path, col_names = TRUE),
     error = function(e) {
       hintr_error(t_("FAILED_READ_CSV"), "INVALID_FILE")
     }
@@ -215,7 +215,7 @@ do_validate_anc <- function(anc, shape, strict = TRUE) {
 do_validate_survey <- function(survey, shape, strict = TRUE) {
   assert_file_extension(survey, "csv")
   withCallingHandlers(
-    data <- read_csv(survey$path, header = TRUE),
+    data <- read_csv(survey$path, col_names = TRUE),
     error = function(e) {
       hintr_error(t_("FAILED_READ_CSV"), "INVALID_FILE")
     }

--- a/R/worker_config.R
+++ b/R/worker_config.R
@@ -95,3 +95,12 @@ get_queue_from_job_name <- function(job_name, iso3 = NULL,
     queue_config$default
   }
 }
+
+validate_worker_name <- function(name) {
+  if (!(name %in% names(cfg$workers$workers))) {
+    stop(paste0("Cannot start worker with config '",
+                name,
+                "' this is not in configuration."))
+  }
+  invisible(TRUE)
+}

--- a/R/worker_config.R
+++ b/R/worker_config.R
@@ -1,0 +1,97 @@
+read_worker_config <- function() {
+  ## Read app config if we have this setup with env vars
+  config <- jsonlite::read_json(system_file("worker_config.json"),
+                                simplifyVector = TRUE)
+
+  ## Reverse the order of the job config so that lookups later are easier
+  ## we want something like list(job_name = list(country_iso3 = queue_name)))
+  config$job_mapping <- parse_and_validate_worker_config(config)
+  config
+}
+
+register_workers <- function(controller) {
+  for (worker_name in names(cfg$workers$workers)) {
+    args <- cfg$workers$workers[[worker_name]]
+    args_pass <- args[formalArgs(rrq::rrq_worker_config)]
+    args_pass <- args_pass[!vlapply(args_pass, is.null)]
+    message(paste0("Registering worker ", worker_name,
+                   " processing queue(s): '",
+                   collapse(args_pass$queue, "', '"),
+                   "'"))
+    worker_cfg <- do.call(rrq::rrq_worker_config,
+                          args = args_pass)
+    rrq::rrq_worker_config_save(worker_name, worker_cfg,
+                                controller = controller)
+  }
+}
+
+parse_and_validate_worker_config <- function(config) {
+  if (!setequal(names(config), c("workers", "queues"))) {
+    stop("Worker config must only have keys 'workers' and 'queues'.")
+  }
+  queue_names <- names(config$queues)
+  for (worker_name in names(config$workers)) {
+    worker <- config$workers[[worker_name]]
+    missing <- !(worker$queue %in% queue_names)
+    if (any(missing)) {
+      stop(paste0("Worker '", worker_name,
+                 "' is configured to listen to queue(s) '",
+                 collapse(worker$queue[missing], collapse = "', '"),
+                 "' which is/are missing from config."))
+    }
+  }
+
+  job_mapping <- build_job_mappings(config$queues)
+
+  ## Assert that:
+  ##   * One and only one queue has "default" for each job
+  ##   * A country is not present more than once for each job
+  for (job_name in names(job_mapping)) {
+    job_cfg <- job_mapping[[job_name]]
+    country_names <- names(job_cfg)
+    dupes <- country_names[duplicated(country_names)]
+    if (length(dupes) > 0) {
+      stop(paste0("Multiple queues configured to handle the same job. Job '",
+                  job_name,
+                  "' for country '",
+                  collapse(dupes[[1]]),
+                  "' is configured on multiple queues. It must be handled by a ",
+                  "single queue."))
+    }
+  }
+
+  job_mapping
+}
+
+build_job_mappings <- function(queues) {
+  mappings <- list()
+  for (queue_name in names(queues)) {
+    queue_config <- queues[[queue_name]]
+
+    lapply(names(queue_config$jobs), function(job_name) {
+      countries <- queue_config$jobs[[job_name]]
+      job <- stats::setNames(
+        lapply(seq_along(countries), function(x) queue_name),
+        countries)
+      if (!(job_name %in% names(mappings))) {
+        mappings[job_name] <<- list(job)
+      } else {
+        mappings[[job_name]] <<- c(mappings[[job_name]], job)
+      }
+    })
+  }
+  mappings
+}
+
+get_queue_from_job_name <- function(job_name, iso3 = NULL,
+                                    worker_config = cfg$workers) {
+  if (!(job_name %in% names(worker_config$job_mapping))) {
+    hintr_error(t_("FAILED_QUEUE"), "INVALID_QUEUE_CONFIG")
+  }
+  queue_config <- worker_config$job_mapping[[job_name]]
+  if (!is.null(iso3) && iso3 %in% names(queue_config)) {
+    queue_config[[iso3]]
+  } else {
+    queue_config$default
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,6 +13,7 @@ cfg <- new.env(parent = emptyenv())
 .onLoad <- function(...) {
   cfg$version_info <- get_version_info() # nocov
   hintr_init_traduire() # nocov
+  cfg$workers <- read_worker_config()
 }
 
 get_version_info <- function() {

--- a/inst/payload/model_calibrate_payload.json
+++ b/inst/payload/model_calibrate_payload.json
@@ -10,5 +10,6 @@
     "spectrum_aware_calibration_strat": "sex_age_coarse",
     "calibrate_method": "logistic"
   },
-  "version": "<+version_info+>"
+  "version": "<+version_info+>",
+  "iso3": "MWI"
 }

--- a/inst/payload/model_submit_payload.json
+++ b/inst/payload/model_submit_payload.json
@@ -80,5 +80,6 @@
     "max_iter": 250,
     "psnu_level": null
   },
-  "version": "<+version_info+>"
+  "version": "<+version_info+>",
+  "iso3": "MWI"
 }

--- a/inst/payload/model_submit_payload_minimal.json
+++ b/inst/payload/model_submit_payload_minimal.json
@@ -51,5 +51,6 @@
     "max_iter": 250,
     "psnu_level": null
   },
-  "version": "<+version_info+>"
+  "version": "<+version_info+>",
+  "iso3": "MWI"
 }

--- a/inst/schema/CalibrateSubmitRequest.schema.json
+++ b/inst/schema/CalibrateSubmitRequest.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "options" : { "type": "object" },
-    "version": { "$ref": "VersionInfo.schema.json" }
+    "version": { "$ref": "VersionInfo.schema.json" },
+    "iso3": { "type": "string" }
   },
   "additionalProperties": false,
   "required": [
     "options",
-    "version"
+    "version",
+    "iso3"
   ]
 }

--- a/inst/schema/DownloadSubmitRequest.schema.json
+++ b/inst/schema/DownloadSubmitRequest.schema.json
@@ -5,7 +5,9 @@
     "notes": { "$ref": "Notes.schema.json" },
     "state": { "$ref": "ProjectState.schema.json" },
     "pjnz": { "$ref": "SessionFile.schema.json" },
-    "vmmc": { "$ref": "SessionFile.schema.json" }
+    "vmmc": { "$ref": "SessionFile.schema.json" },
+    "iso3": { "type": "string" }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": [ "iso3" ]
 }

--- a/inst/schema/ModelSubmitRequest.schema.json
+++ b/inst/schema/ModelSubmitRequest.schema.json
@@ -4,12 +4,14 @@
   "properties": {
     "data" : { "$ref": "ModelSubmitData.schema.json" },
     "options" : { "type": "object" },
-    "version": { "$ref": "VersionInfo.schema.json" }
+    "version": { "$ref": "VersionInfo.schema.json" },
+    "iso3": { "type": "string" }
   },
   "additionalProperties": false,
   "required": [
     "data",
     "options",
-    "version"
+    "version",
+    "iso3"
   ]
 }

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -118,5 +118,6 @@
     "NUMBER_ON_ART_ADULT_FEMALE": "Female ART",
     "NUMBER_ON_ART_ADULT_MALE": "Male ART",
     "NUMBER_ON_ART_CHILDREN": "Children ART",
-    "FAILED_READ_CSV": "Failed to read file. Please review input file and check it is a valid csv."
+    "FAILED_READ_CSV": "Failed to read file. Please review input file and check it is a valid csv.",
+    "FAILED_QUEUE": "Failed to get relevant queue from config, please contact a system admin."
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -119,5 +119,6 @@
     "NUMBER_ON_ART_ADULT_FEMALE": "Femmes TARV",
     "NUMBER_ON_ART_ADULT_MALE": "Hommes TARV",
     "NUMBER_ON_ART_CHILDREN": "Enfants TARV",
-    "FAILED_READ_CSV": "Échec de la lecture du fichier ANC. Veuillez revoir le fichier et vérifier qu'il s'agit d'un fichier csv valide."
+    "FAILED_READ_CSV": "Échec de la lecture du fichier ANC. Veuillez revoir le fichier et vérifier qu'il s'agit d'un fichier csv valide.",
+    "FAILED_QUEUE": "Impossible d'obtenir la file d'attente appropriée à partir de la configuration, veuillez contacter un administrateur système."
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -118,5 +118,6 @@
     "NUMBER_ON_ART_ADULT_FEMALE": "Mulheres TARV",
     "NUMBER_ON_ART_ADULT_MALE": "Homens ART",
     "NUMBER_ON_ART_CHILDREN": "Crianças ART",
-    "FAILED_READ_CSV": "Falha na leitura do ficheiro. Reveja o ficheiro de entrada e verifique se é um csv válido."
+    "FAILED_READ_CSV": "Falha na leitura do ficheiro. Reveja o ficheiro de entrada e verifique se é um csv válido.",
+    "FAILED_QUEUE": "Falha ao obter a fila relevante da configuração, entre em contato com um administrador do sistema."
 }

--- a/inst/worker_config.json
+++ b/inst/worker_config.json
@@ -1,0 +1,37 @@
+{
+  "workers": {
+    "localhost": {
+      "queue": ["calibrate", "run"],
+      "heartbeat_period": 10
+    },
+    "calibrate_only": {
+      "queue": ["calibrate"],
+      "heartbeat_period": 10
+    },
+    "fit_only": {
+      "queue": ["run"],
+      "heartbeat_period": 10
+    }
+  },
+  "queues": {
+    "run": {
+      "jobs": {
+        "fit": "default"
+      },
+      "wake_up": false
+    },
+    "calibrate": {
+      "jobs": {
+        "calibrate": "default",
+        "spectrum": "default",
+        "coarse_output": "default",
+        "summary": "default",
+        "comparison": "default",
+        "agyw": "default",
+        "datapack": "default",
+        "rehydrate": "default"
+      },
+      "wake_up": false
+    }
+  }
+}

--- a/scripts/read_har.R
+++ b/scripts/read_har.R
@@ -1,0 +1,107 @@
+read_har <- function(path, source_site) {
+  json <- jsonlite::read_json(path)
+  entries <- lapply(json$log$entries, parse_entry)
+  entries <- discard_non_hint(entries)
+  entries <- lapply(entries, function(entry) {
+    entry$source <- source_site
+    entry
+  })
+  entries <- group_entries(entries)
+}
+
+## Parse a har file entry, contains keys
+## startedDateTime
+## request
+## response
+## We want the time time, url
+##
+parse_entry <- function(entry) {
+  list(
+    url = entry$request$url,
+    start = entry$startedDateTime,
+    time = entry$time
+  )
+}
+
+hint_domains <- list(
+  "naomi.unaids.org",
+  "naomi-preview.dide.ic.ac.uk",
+  "nm-hint.azurewebsites.net"
+)
+
+is_hint_entry <- function(entry) {
+  urltools::domain(entry$url) %in% hint_domains
+}
+
+discard_non_hint <- function(entries) {
+  hint_entry <- vapply(entries, is_hint_entry, logical(1))
+  entries[hint_entry]
+}
+
+group_entries <- function(entries) {
+  add_group <- function(entry) {
+    ## Pattern to label I want to use
+    entrypoint <- urltools::path(entry$url)
+    groups <- list(
+      "adr/datasets/<id>" = "adr\\/datasets\\/",
+      "project/<id>/version" = "project\\/\\d+\\/version",
+      "<type>/status/<id>" = "\\w+\\/status\\/\\w+",
+      "meta/adr/<id>" = "meta\\/adr\\/",
+      "meta/review-inputs/<iso3>" = "meta\\/review-inputs\\/",
+      "model/result/<id>" = "model\\/result\\/",
+      "calibrate/options/<iso3>" = "calibrate\\/options\\/",
+      "calibrate/submit/<id>" = "calibrate\\/submit\\/",
+      "calibrate/result/metadata/<id>" = "calibrate\\/result\\/metadata\\/",
+      "calibrate/result/filteredData/<id>" = "calibrate\\/result\\/filteredData\\/",
+      "calibrate/plot/<id>" = "calibrate\\/plot\\/",
+      "model/comparison/plot/<id>" = "model\\/comparison\\/plot\\/",
+      "download/submit/<type>/<id>" = "download\\/submit\\/",
+      "download/result/<id>" = "download\\/result\\/"
+    )
+    for (group in names(groups)) {
+      if (grepl(groups[[group]], entrypoint)) {
+        entrypoint <- group
+      }
+    }
+    entry$group <- entrypoint
+    entry
+  }
+  do.call(rbind.data.frame, lapply(entries, add_group))
+}
+
+summarise_har <- function(har) {
+  har |>
+    dplyr::group_by(group, source) |>
+    dplyr::summarize(mean = mean(time), sd = sd(time), n = dplyr::n()) |>
+    dplyr::ungroup()
+}
+
+plot_har <- function(har, n_bars) {
+  har <- dplyr::filter(har, mean > 0)
+  ggplot2::ggplot(har, ggplot2::aes(x = group, y = mean, fill = source)) +
+    ggplot2::geom_bar(position = ggplot2::position_dodge(), stat = "identity") +
+    ggplot2::geom_errorbar(ggplot2::aes(ymin = mean - sd, ymax = mean + sd),
+                           size = 0.3,
+                           width = 0.2,
+                           position = ggplot2::position_dodge(0.9)) +
+    ggplot2::xlab("Endpoint") +
+    ggplot2::ylab("Mean time") +
+    ggplot2::theme_minimal() +
+    ggplot2::ggtitle("Mean request time") +
+    ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1))
+}
+
+plot_all <- function(paths, n_bars) {
+  har <- lapply(names(paths), function(nm) read_har(paths[[nm]], nm))
+  har <- do.call(rbind.data.frame, har)
+  summary <- summarise_har(har)
+  plot_har(summary, n_bars)
+}
+
+## Update this to point to your files
+paths <- list(
+  "UK Azure" = "~/nm-hint.azurewebsites.net_Archive [25-02-24 17-28-55].har",
+  "UK Prod" = "~/naomi.unaids.org_Archive [25-02-24 17-27-17].har",
+  "US Azure" = "~/Downloads/nm-hint.azurewebsites.net.har",
+  "US Prod" = "~/Downloads/naomi.unaids.org.har")
+plot_all(paths, 10)

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -13,12 +13,12 @@ MockQueue <- R6::R6Class(
   inherit = Queue,
   cloneable = FALSE,
   public = list(
-    submit_model_run = function(data, options) {
+    submit_model_run = function(data, options, iso3) {
       rrq::rrq_task_create_expr(stop("test error"),
                                 controller = self$controller)
     },
 
-    submit_calibrate = function(data, options) {
+    submit_calibrate = function(data, options, iso3) {
       rrq::rrq_task_create_expr(stop("test error"),
                                 controller = self$controller)
     }
@@ -34,6 +34,9 @@ test_queue <- function(queue_id = NULL, workers = 0, delete_data_on_exit = TRUE)
   })
   queue
 }
+
+QUEUE_CALIBRATE <- "calibrate"
+QUEUE_RUN <- "run"
 
 create_blocking_worker <- function(controller, worker_name = NULL) {
   ## Set config for a blocking worker

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -4,7 +4,8 @@ dir.create(results_dir)
 withr::with_dir(testthat::test_path(), {
   server <- porcelain::porcelain_background$new(
     api, args = list(queue_id = paste0("hintr:", ids::random_id()),
-                     results_dir = results_dir))
+                     results_dir = results_dir),
+    verbose = TRUE)
   server$start()
 })
 
@@ -575,8 +576,11 @@ test_that("download streams bytes", {
   })
 
   ## Start the download
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   r <- server$request("POST",
-                      paste0("/download/submit/spectrum/", calibrate_id))
+                      paste0("/download/submit/spectrum/", calibrate_id),
+                      body = payload)
   response <- response_from_json(r)
   expect_equal(httr::status_code(r), 200)
   expect_true(!is.null(response$data$id))

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -580,7 +580,8 @@ test_that("download streams bytes", {
                                             include_state = FALSE)
   r <- server$request("POST",
                       paste0("/download/submit/spectrum/", calibrate_id),
-                      body = payload)
+                      body = payload,
+                      httr::content_type_json())
   response <- response_from_json(r)
   expect_equal(httr::status_code(r), 200)
   expect_true(!is.null(response$data$id))

--- a/tests/testthat/test-01-endpoints-download.R
+++ b/tests/testthat/test-01-endpoints-download.R
@@ -3,8 +3,10 @@ test_that("spectrum download returns bytes", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "spectrum")
+  submit_response <- submit$run(q$calibrate_id, "spectrum", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -63,8 +65,11 @@ test_that("api can call spectrum download", {
   api <- api_build(q$queue)
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- api$request("POST",
-                        paste0("/download/submit/spectrum/", q$calibrate_id))
+                        paste0("/download/submit/spectrum/", q$calibrate_id),
+                        body = payload)
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
   expect_true(!is.null(submit_body$data$id))
@@ -112,8 +117,10 @@ test_that("coarse output download returns bytes", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "coarse_output")
+  submit_response <- submit$run(q$calibrate_id, "coarse_output", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -149,8 +156,11 @@ test_that("api can call coarse_output download", {
   api <- api_build(q$queue)
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- api$request("POST", paste0("/download/submit/coarse-output/",
-                                      q$calibrate_id))
+                                      q$calibrate_id),
+                        body = payload)
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
   expect_true(!is.null(submit_body$data$id))
@@ -189,8 +199,10 @@ test_that("summary report download returns bytes", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "summary")
+  submit_response <- submit$run(q$calibrate_id, "summary", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -228,8 +240,11 @@ test_that("api can call summary report download", {
   api <- api_build(q$queue)
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- api$request("POST", paste0("/download/submit/summary/",
-                                      q$calibrate_id))
+                                      q$calibrate_id),
+                        body = payload)
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
   expect_true(!is.null(submit_body$data$id))
@@ -300,9 +315,11 @@ test_that("download returns useful error if model result can't be retrieved", {
   test_mock_model_available()
 
   ## Try to download with task ID doesn't exist
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   queue <- test_queue(workers = 0)
   download <- download_submit(queue)
-  error <- expect_error(download("id1", "spectrum"))
+  error <- expect_error(download("id1", "spectrum", payload))
   expect_equal(error$data[[1]]$error, scalar("FAILED_TO_RETRIEVE_RESULT"))
   expect_equal(error$data[[1]]$detail, scalar("Failed to fetch result"))
   expect_equal(error$status_code, 400)
@@ -417,8 +434,10 @@ test_that("comparison report download returns bytes", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "comparison")
+  submit_response <- submit$run(q$calibrate_id, "comparison", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -456,8 +475,11 @@ test_that("api can call comparison report download", {
   api <- api_build(q$queue)
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- api$request("POST", paste0("/download/submit/comparison/",
-                                      q$calibrate_id))
+                                      q$calibrate_id),
+                        body = payload)
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
   expect_true(!is.null(submit_body$data$id))
@@ -831,9 +853,11 @@ test_that("spectrum download is translated", {
   test_mock_model_available()
   q <- test_queue_result()
 
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   response <- with_hintr_language("fr", {
     submit <- endpoint_download_submit(q$queue)
-    submit_response <- submit$run(q$calibrate_id, "spectrum")
+    submit_response <- submit$run(q$calibrate_id, "spectrum", payload)
   })
 
   expect_equal(submit_response$status_code, 200)

--- a/tests/testthat/test-04-adr-metadata.R
+++ b/tests/testthat/test-04-adr-metadata.R
@@ -3,8 +3,10 @@ test_that("can return upload metadata for ADR spectrum", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "spectrum")
+  submit_response <- submit$run(q$calibrate_id, "spectrum", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -33,8 +35,10 @@ test_that("can return upload metadata for ADR coarse-output", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "coarse-output")
+  submit_response <- submit$run(q$calibrate_id, "coarse-output", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -63,8 +67,10 @@ test_that("can return upload metadata for ADR summary report", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "summary")
+  submit_response <- submit$run(q$calibrate_id, "summary", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -93,8 +99,10 @@ test_that("can return upload metadata for comparison report", {
   q <- test_queue_result()
 
   ## Submit download request
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "comparison")
+  submit_response <- submit$run(q$calibrate_id, "comparison", payload)
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))

--- a/tests/testthat/test-06-debug.R
+++ b/tests/testthat/test-06-debug.R
@@ -85,8 +85,10 @@ test_that("Debug endpoint returns debug information for download", {
   test_mock_model_available()
   q <- test_queue_result()
 
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "spectrum")
+  submit_response <- submit$run(q$calibrate_id, "spectrum", payload)
   id <- submit_response$data$id
 
   expect_equal(submit_response$status_code, 200)

--- a/tests/testthat/test-07-endpoints-model.R
+++ b/tests/testthat/test-07-endpoints-model.R
@@ -51,7 +51,9 @@ test_that("endpoint_run_model returns error if queueing fails", {
 
   ## Create mocks
   queue <- test_queue()
-  mock_submit_model_run <- function(data, options) { stop("Failed to queue") }
+  mock_submit_model_run <- function(data, options, iso3) {
+    stop("Failed to queue")
+  }
 
   ## Call the endpoint
   model_submit <- submit_model(queue)

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -203,7 +203,7 @@ test_that("error thrown when tree can't be constructed", {
 
 test_that("can get indicator filters for survey data", {
   survey_path <- file.path("testdata", "survey.csv")
-  survey <- read_csv(survey_path, header = TRUE)
+  survey <- read_csv(survey_path, col_names = TRUE)
   filters <- get_indicator_filters(survey, "survey")
 
   expect_length(filters, 4)
@@ -219,7 +219,7 @@ test_that("can get indicator filters for survey data", {
 
 test_that("can get indicator filters for programme data", {
   programme_path <- file.path("testdata", "programme.csv")
-  programme <- read_csv(programme_path, header = TRUE)
+  programme <- read_csv(programme_path, col_names = TRUE)
   filters <- get_indicator_filters(programme, "programme")
 
   expect_length(filters, 4)
@@ -235,7 +235,7 @@ test_that("can get indicator filters for programme data", {
 
 test_that("can get indicator filters for anc data", {
   anc_path <- file.path("testdata", "anc.csv")
-  anc <- read_csv(anc_path, header = TRUE)
+  anc <- read_csv(anc_path, col_names = TRUE)
   ## We will have calculated prev and art coverage for ANC data
   anc <- naomi::calculate_prevalence_art_coverage(anc)
   filters <- get_indicator_filters(anc, "anc")

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -15,17 +15,17 @@ test_that("main_api_args", {
 
 test_that("main_worker_args", {
   expect_equal(main_worker_args(c()),
-               list(queue_id = NULL, calibrate_only = FALSE))
-  expect_equal(main_worker_args("hintr"),
-               list(queue_id = "hintr", calibrate_only = FALSE))
-  expect_equal(main_worker_args(c("--calibrate-only")),
-               list(queue_id = NULL, calibrate_only = TRUE))
+               list(queue_id = NULL, worker_config = NULL))
+  expect_equal(main_worker_args("localhost"),
+               list(queue_id = NULL, worker_config = "localhost"))
+  expect_equal(main_worker_args(c("localhost", "hintr")),
+               list(queue_id = "hintr", worker_config = "localhost"))
 })
 
 test_that("main worker creates worker with multiple queues", {
   mock_rrq_worker <- mockery::mock(list(loop = function() TRUE, cycle = TRUE))
   with_mocked_bindings(
-    worker <- main_worker("queue_id"),
+    worker <- main_worker(c("localhost", "queue_id")),
     rrq_worker_new = mock_rrq_worker
   )
   args <- mockery::mock_args(mock_rrq_worker)[[1]]
@@ -36,7 +36,7 @@ test_that("main worker creates worker with multiple queues", {
 test_that("main worker can create a calibrate only worker", {
   mock_rrq_worker <- mockery::mock(list(loop = function() TRUE, cycle = TRUE))
   with_mocked_bindings(
-    worker <- main_worker(c("--calibrate-only", "queue_id")),
+    worker <- main_worker(c("calibrate_only", "queue_id")),
     rrq_worker_new = mock_rrq_worker
   )
   args <- mockery::mock_args(mock_rrq_worker)[[1]]
@@ -48,7 +48,7 @@ test_that("main worker single job can create a fit only worker", {
   mock_rrq_worker <- mockery::mock(
     list(step = function(immediate) TRUE, cycle = TRUE))
   with_mocked_bindings(
-    worker <- main_worker_single_job(c("--fit-only", "queue_id")),
+    worker <- main_worker_single_job(c("fit_only", "queue_id")),
     rrq_worker_new = mock_rrq_worker
   )
   args <- mockery::mock_args(mock_rrq_worker)[[1]]

--- a/tests/testthat/test-migrations.R
+++ b/tests/testthat/test-migrations.R
@@ -59,8 +59,10 @@ test_that("download output format is not migrated", {
   q <- test_queue_result()
 
   ## Submit download request and wait for it to complete
+  payload <- setup_payload_download_request(include_notes = FALSE,
+                                            include_state = FALSE)
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "coarse_output")
+  submit_response <- submit$run(q$calibrate_id, "coarse_output", payload)
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
   out <- q$queue$task_wait(submit_response$data$id)

--- a/tests/testthat/test-payload-helpers.R
+++ b/tests/testthat/test-payload-helpers.R
@@ -1,6 +1,0 @@
-test_that("error thrown if trying to create invalid download payload", {
-  expect_error(setup_payload_download_request(include_notes = FALSE,
-                                              include_state = FALSE,
-                                              include_pjnz = FALSE),
-               "Must include one or more of notes, state or pjnz in payload")
-})

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -30,7 +30,7 @@ test_that("queue works as intended", {
   expect_length(rrq::rrq_task_list(controller = ctrl), 0)
 
   ## model run can be pushed to queue
-  job_id <- queue$submit_model_run(NULL, list())
+  job_id <- queue$submit_model_run(NULL, list(), "MWI")
   expect_length(rrq::rrq_task_list(controller = ctrl), 1)
 
   ## status can be retireved
@@ -117,9 +117,9 @@ test_that("queue starts up normally without a timeout", {
 
 test_that("queue object starts up 2 queues", {
   queue <- test_queue(workers = 2)
-  expect_equal(rrq::rrq_worker_config_read("localhost",
-                                           controller = queue$controller)$queue,
-               c(QUEUE_CALIBRATE, QUEUE_RUN, "default"))
+  expect_setequal(rrq::rrq_worker_config_read(
+    "localhost", controller = queue$controller)$queue,
+    c(QUEUE_CALIBRATE, QUEUE_RUN, "default"))
 })
 
 test_that("calibrate gets run before model running", {
@@ -129,10 +129,10 @@ test_that("calibrate gets run before model running", {
   queue <- test_queue(workers = 0, delete_data_on_exit = FALSE)
   ctrl <- queue$controller
   worker <- create_blocking_worker(queue$controller)
-  run_id <- queue$submit_model_run(NULL, NULL)
+  run_id <- queue$submit_model_run(NULL, NULL, "MWI")
   ## Calibrate tasks will error but that is fine - we want to test here
   ## that calibrate & model run get queued and run in the correct order
-  calibrate_id <- queue$submit_calibrate(NULL, NULL)
+  calibrate_id <- queue$submit_calibrate(NULL, NULL, "MWI")
 
   expect_equal(rrq::rrq_task_status(c(run_id, calibrate_id), controller = ctrl),
                rep("PENDING", 2))

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -1,0 +1,159 @@
+test_that("can build job mapping", {
+  queues <- list(
+    run = list(
+      jobs = list(
+        fit = "default"
+      )
+    )
+  )
+  mappings <- build_job_mappings(queues)
+  expect_equal(mappings, list(fit = list(default = "run")))
+
+  queues <- list(
+    run = list(
+      jobs = list(
+        fit = "default"
+      )
+    ),
+    calibrate_only = list(
+      jobs = list(
+        calibrate = "default",
+        spectrum = "default"
+      )
+    )
+  )
+  mappings <- build_job_mappings(queues)
+  expect_equal(mappings, list(
+    fit = list(default = "run"),
+    calibrate = list(default = "calibrate_only"),
+    spectrum = list(default = "calibrate_only")
+  ))
+
+  queues <- list(
+    small = list(
+      jobs = list(
+        fit = "default",
+        spectrum = "default"
+      )
+    ),
+    large = list(
+      jobs = list(
+        fit = c('COD', 'MOZ'),
+        calibrate = "default",
+        spectrum = c('COD')
+      )
+    )
+  )
+  mappings <- build_job_mappings(queues)
+  expect_equal(mappings, list(
+    fit = list(default = "small", COD = "large", MOZ = "large"),
+    spectrum = list(default = "small", COD = "large"),
+    calibrate = list(default = "large")
+  ))
+
+  queues <- list(
+    small = list(
+      jobs = list(
+        fit = "default",
+        spectrum = "default"
+      )
+    ),
+    medium = list(
+      jobs = list(
+        fit = 'TZA'
+      )
+    ),
+    large = list(
+      jobs = list(
+        fit = c('COD', 'MOZ'),
+        calibrate = "default",
+        spectrum = c('COD')
+      )
+    )
+  )
+  mappings <- build_job_mappings(queues)
+  expect_equal(mappings, list(
+    fit = list(default = "small", TZA = "medium", COD = "large", MOZ = "large"),
+    spectrum = list(default = "small", COD = "large"),
+    calibrate = list(default = "large")
+  ))
+})
+
+test_that("worker config must container expected keys", {
+  expect_error(
+    parse_and_validate_worker_config(list()),
+    "Worker config must only have keys 'workers' and 'queues'.",
+    fixed = TRUE
+  )
+})
+
+test_that("worker config must not reference unkown queues", {
+  config <- list(
+    workers = list(
+      x = list(
+        queue = "missing",
+        heartbeat_period = 2,
+        wake_up = TRUE
+      )
+    ),
+    queues = list()
+  )
+  expect_error(
+    parse_and_validate_worker_config(config),
+    paste("Worker 'x' is configured to listen to queue(s)",
+          "'missing' which is/are missing from config"),
+    fixed = TRUE
+  )
+})
+
+test_that("worker config invalid if duplicate country per job", {
+  config <- list(
+    workers = list(
+      x = list(
+        queue = "q",
+        heartbeat_period = 2,
+        wake_up = TRUE
+      )
+    ),
+    queues = list(
+      q = list(
+        jobs = list(
+          fit = 'default'
+        )
+      ),
+      q2 = list(
+        jobs = list(
+          fit = 'default'
+        )
+      )
+    )
+  )
+  expect_error(
+    parse_and_validate_worker_config(config),
+    paste("Multiple queues configured to handle the same job. Job 'fit' for",
+          "country 'default' is configured on multiple queues. It must be",
+          "handled by a single queue."),
+    fixed = TRUE
+  )
+})
+
+test_that("can get worker from loaded worker config", {
+  worker_cfg <- list(
+    job_mapping = list(
+      fit = list(
+        default = "run",
+        COD = "large"
+      ),
+      calibrate = list(
+        default = "calibrate"
+      )
+    )
+  )
+  expect_equal(get_queue_from_job_name("fit", "MWI", worker_cfg), "run")
+  expect_equal(get_queue_from_job_name("fit", "COD", worker_cfg), "large")
+  expect_equal(get_queue_from_job_name("fit", NULL, worker_cfg), "run")
+  expect_equal(get_queue_from_job_name("calibrate", "COD", worker_cfg),
+               "calibrate")
+  expect_error(get_queue_from_job_name("unk", "MWI", worker_cfg),
+               "Failed to get relevant queue from config")
+})

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -157,3 +157,10 @@ test_that("can get worker from loaded worker config", {
   expect_error(get_queue_from_job_name("unk", "MWI", worker_cfg),
                "Failed to get relevant queue from config")
 })
+
+test_that("can check for valid worker name", {
+  expect_true(validate_worker_name("localhost"))
+  expect_error(validate_worker_name("unk"),
+               paste("Cannot start worker with config 'unk'",
+                     "this is not in configuration."))
+})


### PR DESCRIPTION
At the moment the worker and queue set-up is done in the package. I want to make this easier to modify on the move to the cloud because we're going to have to be more careful with resources.

With our cloud setup we can run on "consumption" or "workload" profiles, consumption is for <8GB of RAM and will spin up quickly, pretty much taking as much time as it takes to pull the docker container. Workload profiles for anything more than this basically spin up a VM and use this. So the startup time for this is larger.

So what I want to do, is to be able to configure per-country and per-job (model fit, calibrate, download etc.) where these run. And I want to be able to easily modify this during a workshop should we need to. (side note I've added a model option to force the fit onto the biggest node as Rachel and Jeff can bypass this should they need to - https://github.com/mrc-ide/naomi.options/pull/28)

So this PR does a few things
1. Make the workers and queue setup configurable via JSON, the config in the package here should be the same as what we are currently doing
2. I was getting an intermittent error from fread, it has been a long standing bit of work on my todo list to drop the usage of this in favour of readr so I have done this here too. This is what the naomi package is using for reading so should mean we have more consistent behaviour with them, and means we can cut down the size of the docker image a bit as we can remove the data.table depedency
3. Also added a small unrelated helper script for plotting average requests times from har files, I was using this for a bit of profiling comparison between current prod and azure deployment


## Follow up work
1. Update the deploy tool to use the new syntax for the entrypoint functions
2. Add ability to pull the configuration from azure config, and fallback to the one baked into the package if not set on the cloud
3. Add a wake up endpoint
4. Remove data.table from docker image build

