### PR TITLE
[NM-117] Update comparison plot and table to return prepared data

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mrc-ide/naomi
-          ref: 4e9a9b81ae86fabd81f9d1905bfc4c0554af7602
+          ## ref: feature-branch
           ## ${{ github.token }} is scoped to the current repository, so we
           ## need to provide our own PAT
           token: ${{ secrets.NAOMI_GH_PAT }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     glue,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (== 2.10.8),
+    naomi (>= 2.10.9),
     naomi.options (>= 1.1.0),
     porcelain (>= 0.1.8),
     qs,
@@ -56,7 +56,7 @@ Suggests:
     tidyselect,
     withr
 Remotes:
-    mrc-ide/naomi@4e9a9b81ae86fabd81f9d1905bfc4c0554af7602
+    mrc-ide/naomi
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 VignetteBuilder: knitr

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 ## Remove the large test data not needed for runtime
 RUN install_packages remotes \
-    && install_remote mrc-ide/naomi@4e9a9b81ae86fabd81f9d1905bfc4c0554af7602 \
+    && install_remote mrc-ide/naomi \
     && rm -r /usr/local/lib/R/site-library/naomi/extdata
 
 WORKDIR /src

--- a/inst/schema/InputComparisonArtRow.schema.json
+++ b/inst/schema/InputComparisonArtRow.schema.json
@@ -25,10 +25,17 @@
     },
     "value_spectrum_reallocated": {
       "type": ["number", "null"]
+    },
+    "difference": {
+      "type": ["number", "null"]
+    },
+    "difference_ratio": {
+      "type": ["number", "null"]
     }
   },
   "additionalProperties": true,
   "required": [ "indicator", "area_name", "year", "group",
                 "value_spectrum_reported", "value_spectrum_adjusted",
-                "value_naomi", "value_spectrum_reallocated" ]
+                "value_naomi", "value_spectrum_reallocated",
+                "difference", "difference_ratio"]
 }


### PR DESCRIPTION
At the moment for the comparison table we calculate the difference column in the font-end. Rachel is preparing this anyway, and she wants to be in control of where those numbers are coming from. So this PR removes the branch pin to turn the feature back on, and returns those difference columns.