### PR TITLE
[NM-122] Pass PJNZ through to input time series programme data

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mrc-ide/naomi
-          ## ref: feature-branch
+          ref: nm-122
           ## ${{ github.token }} is scoped to the current repository, so we
           ## need to provide our own PAT
           token: ${{ secrets.NAOMI_GH_PAT }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     glue,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 2.10.9),
+    naomi (>= 2.10.13),
     naomi.options (>= 1.1.0),
     porcelain (>= 0.1.8),
     qs,
@@ -56,7 +56,7 @@ Suggests:
     tidyselect,
     withr
 Remotes:
-    mrc-ide/naomi
+    mrc-ide/naomi@nm-122
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 VignetteBuilder: knitr

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -123,7 +123,7 @@ input_time_series <- function(type, input) {
       file <- input$data$programme
     }
     assert_file_exists(file$path)
-    get_time_series_data(file, input$data$shape)
+    get_time_series_data(file, input$data$shape, input$data$pjnz)
   },
   error = function(e) {
     hintr_error(api_error_msg(e), "FAILED_TO_GENERATE_TIME_SERIES")

--- a/R/time_series.R
+++ b/R/time_series.R
@@ -1,5 +1,6 @@
-get_programme_time_series <- function(programme, shape) {
-  data <- naomi::prepare_input_time_series_art(programme$path, shape$path)
+get_programme_time_series <- function(programme, shape, pjnz) {
+  data <- naomi::prepare_input_time_series_art(programme$path, shape$path,
+                                               pjnz$path)
   data <- as.data.frame(data, stringsAsFactors = FALSE)
   columns <- get_programme_time_series_columns(data)
   area_level_options <- get_selected_mappings(columns, "area_level",
@@ -24,7 +25,7 @@ get_programme_time_series <- function(programme, shape) {
   )
 }
 
-get_anc_time_series <- function(anc, shape) {
+get_anc_time_series <- function(anc, shape, pjnz = NULL) {
   data <- naomi::prepare_input_time_series_anc(anc$path, shape$path)
   data <- as.data.frame(data, stringsAsFactors = FALSE)
   columns <- get_anc_time_series_columns(data)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 ## Remove the large test data not needed for runtime
 RUN install_packages remotes \
-    && install_remote mrc-ide/naomi \
+    && install_remote mrc-ide/naomi@nm-122 \
     && rm -r /usr/local/lib/R/site-library/naomi/extdata
 
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/hivtools/naomi-base:latest AS build
 
+RUN apt-get update && apt-get install -y \
+    pkg-config
+
 COPY . /src
 COPY docker/bin /usr/local/bin/
 COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site

--- a/inst/schema/InputTimeSeriesRequest.schema.json
+++ b/inst/schema/InputTimeSeriesRequest.schema.json
@@ -7,11 +7,12 @@
       "properties": {
         "shape": { "$ref": "SessionFile.schema.json" },
         "programme": { "$ref": "SessionFile.schema.json" },
-        "anc": { "$ref": "SessionFile.schema.json" }
+        "anc": { "$ref": "SessionFile.schema.json" },
+        "pjnz": { "$ref": "SessionFile.schema.json" }
       },
       "anyOf": [
         { "required":
-          [ "shape", "programme" ] },
+          [ "shape", "programme", "pjnz" ] },
         { "required":
           [ "shape", "anc" ] }
       ]

--- a/tests/testthat/helper-payload.R
+++ b/tests/testthat/helper-payload.R
@@ -3,6 +3,8 @@ setup_payload_input_time_series <- function(data_root_dir, file_path, type) {
                         winslash = "/", mustWork = TRUE)
   shape <- normalizePath(file.path(data_root_dir, "malawi.geojson"),
                          winslash = "/", mustWork = TRUE)
+  pjnz <- normalizePath(file.path(data_root_dir, "Malawi2024.PJNZ"),
+                        winslash = "/", mustWork = TRUE)
 
   sprintf(
     '{
@@ -20,9 +22,16 @@ setup_payload_input_time_series <- function(data_root_dir, file_path, type) {
           "filename": "shape_file",
           "fromADR": false,
           "resource_url": "https://adr.unaids.org/file/123.csv"
+        },
+        "pjnz": {
+          "path": "%s",
+          "hash": "6789",
+          "filename": "pjnz",
+          "fromADR": false,
+          "resource_url": "https://adr.unaids.org/file/123.csv"
         }
       }
-    }', type, file, shape)
+    }', type, file, shape, pjnz)
 }
 
 setup_payload_review_inputs_metadata <- function(data_root_dir,

--- a/tests/testthat/test-time-series.R
+++ b/tests/testthat/test-time-series.R
@@ -19,7 +19,7 @@ test_that("get_programme_time_series returns data and columns", {
   expect_equal(columns[[1]]$id, scalar("plot_type"))
   expect_equal(columns[[1]]$column_id, scalar("plot"))
   expect_equal(columns[[1]]$label, scalar("Plot type"))
-  expect_length(columns[[1]]$values, 19)
+  expect_length(columns[[1]]$values, 22)
   expect_setequal(
     names(columns[[1]]$values[[1]]),
     c("id", "label", "description", "format", "accuracy")

--- a/tests/testthat/test-time-series.R
+++ b/tests/testthat/test-time-series.R
@@ -1,7 +1,8 @@
 test_that("get_programme_time_series returns data and columns", {
   programme <- file_object(file.path("testdata", "programme.csv"))
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  out <- get_programme_time_series(programme, shape)
+  pjnz <- file_object(file.path("testdata", "Malawi2024.PJNZ"))
+  out <- get_programme_time_series(programme, shape, pjnz)
 
   expect_equal(names(out), c("data", "metadata", "warnings"))
   expect_true(nrow(out$data) > 100) ## Check that we have read out some data


### PR DESCRIPTION
Same as #557 but without all the metadata changes

So I did #557 adding a new "data source" in the drop down for comparisons but it was too weird and too much special casing. So I have ripped this metadata out in favour of this simpler approach, showing the adjusted indicators in the expanded view